### PR TITLE
updating ePub-browser.ipynb

### DIFF
--- a/1/browser-epub-1.html
+++ b/1/browser-epub-1.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/1/isaw-papers-1.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/1/isaw-papers-1.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/10/browser-epub-10.html
+++ b/10/browser-epub-10.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/10/isaw-papers-10.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/10/isaw-papers-10.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/11/browser-epub-11.html
+++ b/11/browser-epub-11.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/11/isaw-papers-11.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/11/isaw-papers-11.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/12/browser-epub-12.html
+++ b/12/browser-epub-12.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/12/isaw-papers-12.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/12/isaw-papers-12.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/13/browser-epub-13.html
+++ b/13/browser-epub-13.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/13/isaw-papers-13.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/13/isaw-papers-13.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/2/browser-epub-2.html
+++ b/2/browser-epub-2.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/2/isaw-papers-2.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/2/isaw-papers-2.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/3/browser-epub-3.html
+++ b/3/browser-epub-3.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/3/isaw-papers-3.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/3/isaw-papers-3.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/4/browser-epub-4.html
+++ b/4/browser-epub-4.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/4/isaw-papers-4.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/4/isaw-papers-4.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/5/browser-epub-5.html
+++ b/5/browser-epub-5.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/5/isaw-papers-5.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/5/isaw-papers-5.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/6/browser-epub-6.html
+++ b/6/browser-epub-6.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/6/isaw-papers-6.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/6/isaw-papers-6.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/7/browser-epub-7.html
+++ b/7/browser-epub-7.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/7/isaw-papers-7.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/7/isaw-papers-7.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/8/browser-epub-8.html
+++ b/8/browser-epub-8.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/8/isaw-papers-8.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/8/isaw-papers-8.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/9/browser-epub-9.html
+++ b/9/browser-epub-9.html
@@ -67,7 +67,7 @@
 
          <script>
             "use strict";
-            var Book = ePub('https://fmezard.github.io/isaw-papers-ereaders/9/isaw-papers-9.epub');</script>
+            var Book = ePub('https://isawnyu.github.io/isaw-papers-ereaders/9/isaw-papers-9.epub');</script>
     </head>
     <body>
         <div id="main">

--- a/ePub-browser.ipynb
+++ b/ePub-browser.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
     "         <script>\n",
     "            \"use strict\";\n",
     "            var Book = ePub(\"\"\"\n",
-    "        + \"'https://fmezard.github.io/isaw-papers-ereaders/\"+ str(i)+\"/isaw-papers-\"+str(i)+\".epub');\"\n",
+    "        + \"'https://isawnyu.github.io/isaw-papers-ereaders/\"+ str(i)+\"/isaw-papers-\"+str(i)+\".epub');\"\n",
     "        +\"\"\"</script>\n",
     "    </head>\n",
     "    <body>\n",


### PR DESCRIPTION
The html that renders the epubs in the browser now take isawnyu/isaw-papers-ereaders as a source, and not FMezard. 